### PR TITLE
Create composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "require":
+  {
+    "phpclasses/mydql2i": ">=1.6"
+  },
+  "repositories":
+  [
+    {
+      "type": "composer",
+      "url": "https:\/\/www.phpclasses.org\/"
+    },
+    {
+      "packagist": false
+    }
+  ]
+}


### PR DESCRIPTION
The MySQL package is deprecated, we can keep going using this package.
It uses MySQLi by the way, so the original syntax works.